### PR TITLE
First attempt to provide a Mingw cross-compilation Makefile for the

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -557,6 +557,7 @@ then
 		AC_CHECK_OCAML_PKG([ssl], ssl)
                 # Check for the ocaml-ssl version: we only support
                 # version >= 0.4.7
+		AC_CHECK_OCAML_PKG_VERS([ssl], ssl)
                 AX_COMPARE_VERSION([$pkg_vers_ssl], [lt], [0.4.7], [ocaml_ssl_bad_version=yes], [ocaml_ssl_bad_version=no])
                 if test "$ocaml_ssl_bad_version" == "yes"
                 then

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,10 @@ then
 fi
 OCAMLVERSION=$(ocamlc -version)
 AC_MSG_RESULT(OCaml version is $OCAMLVERSION)
+# If OCaml version is < 4.0.2, we don't have the Bytes module: remember this
+# and adapt the makefiles
+AX_COMPARE_VERSION([$OCAMLVERSION], [lt], [4.0.2], [ocaml_with_bytes_module=no], [ocaml_with_bytes_module=yes])
+
 OCAMLLIB=$(ocamlc -where)
 AC_MSG_RESULT(OCaml library path is $OCAMLLIB)
 # checking for ocamlopt
@@ -1351,7 +1355,18 @@ else
 	AC_SUBST(caml_client_ssl_server, "")
 fi
 
-
+# Adding the Bytes modules define if necessary (some functions are deprecated and
+# generate a warning for OCaml versions >= 4.0.2)
+if test "$ocaml_with_bytes_module" == "yes"
+then
+	AC_MSG_NOTICE([OCaml has Bytes module (using it to avoid deprecated functions)])
+        AC_SUBST(ocaml_with_bytes_module, "-DOCAML_WITH_BYTES_MODULE")
+        AC_SUBST(ocaml_with_bytes_module_idl, "-D OCAML_WITH_BYTES_MODULE")
+else
+	AC_MSG_NOTICE([OCaml has not Bytes module (aliasing it as String)])
+        AC_SUBST(ocaml_with_bytes_module, "")
+        AC_SUBST(ocaml_with_bytes_module_idl, "")
+fi
 
 # Compiling with/without the filter
 if test "$with_filter" == "yes"

--- a/src/bindings-pkcs11/Makefile.in
+++ b/src/bindings-pkcs11/Makefile.in
@@ -22,7 +22,7 @@ debug:	@idl_gen@
 
 idl:	
 	@rm -f @idl_clean@
-	camlidl -header @srcdir@/pkcs11.idl
+	camlidl @ocaml_with_bytes_module_idl@ -header @srcdir@/pkcs11.idl
 	cat @srcdir@/pkcs11_stubs.c | sed -e 's/Begin_roots_block(\(.*\)).*/Begin_roots_block(\1);/g' | sed -e 's/Begin_root(\(.*\)).*/Begin_root(\1);/g' | sed -e 's/End_roots(\(.*\)).*/End_roots(\1);/g' > ./tmp
 	mv ./tmp @srcdir@/pkcs11_stubs.c
 	#Sed to patch (GetSlotList/GetMechList/FindObjects/GetObjectSize)

--- a/src/bindings-pkcs11/pkcs11.idl
+++ b/src/bindings-pkcs11/pkcs11.idl
@@ -3176,8 +3176,8 @@ quote(mli, "val sprint_bool_attribute_value : nativeint -> string\n");
 quote(mli, "val sprint_template_array : ck_attribute array -> string\n");
 
 quote(ml,
-      "let char_array_to_string = fun a -> let s = String.create (Array.length a) in\n");
-quote(ml, "  Array.iteri (fun i x -> String.set s i x) a; s;;\n");
+      "let char_array_to_string = fun a -> let s = Bytes.create (Array.length a) in\n");
+quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; s;;\n");
 
 quote(ml,
       "let string_to_char_array = fun s -> Array.init (String.length s) (fun i -> s.[i]);;\n");
@@ -3248,13 +3248,13 @@ quote(ml, "    (res);;");
 quote(ml, "let pack hexstr =");
 quote(ml, "     let len = String.length hexstr in");
 quote(ml, "     let half_len = len / 2 in");
-quote(ml, "     let res = String.create half_len in");
+quote(ml, "     let res = Bytes.create half_len in");
 quote(ml, "     let j = ref 0 in");
 quote(ml, "     for i = 0 to len - 2 do");
 quote(ml, "        if (i mod 2 == 0) then");
 quote(ml, "          (");
 quote(ml, "          let tmp = merge_nibbles hexstr.[i] hexstr.[i+1] in");
-quote(ml, "          res.[!j] <- tmp;");
+quote(ml, "          Bytes.set res !j tmp;");
 quote(ml, "          j := !j +1;");
 quote(ml, "          )");
 quote(ml, "     done;");

--- a/src/bindings-pkcs11/pkcs11.idl
+++ b/src/bindings-pkcs11/pkcs11.idl
@@ -3175,6 +3175,10 @@ quote(mli, "val char_array_to_bool : char array -> nativeint\n");
 quote(mli, "val sprint_bool_attribute_value : nativeint -> string\n");
 quote(mli, "val sprint_template_array : ck_attribute array -> string\n");
 
+/* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module */
+#ifndef OCAML_WITH_BYTES_MODULE 
+quote(ml, "module Bytes = String");
+#endif
 quote(ml,
       "let char_array_to_string = fun a -> let s = Bytes.create (Array.length a) in\n");
 quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; s;;\n");

--- a/src/bindings-pkcs11/pkcs11_stubs.cocci
+++ b/src/bindings-pkcs11/pkcs11_stubs.cocci
@@ -334,6 +334,7 @@ identifier _ctx, _c2, _v4, _c5, _c6, _v7;
 +      }
 +#endif
 +    }
++    /* Fallthrough */
 +    default:  {
 +      if ((long)_c5 >= 0) {
 +        (*_c2).value = camlidl_malloc(_c5 * sizeof(char), _ctx);

--- a/src/client-lib/Makefile.Win32.mingw
+++ b/src/client-lib/Makefile.Win32.mingw
@@ -1,0 +1,113 @@
+#Path to ONC-RPC library and generated STATIC lib file.
+#WARNING: your oncrpc.lib have to match your build configuration (Debug/Release), otherwise it will fail
+#Please download and compile your own (<add project URL>)
+RPC_INC=../../../oncrpc-win32/win32/include
+RPC_LIB32=../../../oncrpc-win32/win32/bin32/oncrpc.lib
+RPC_LIB64=../../../oncrpc-win32/win32/bin64/oncrpc.lib
+SSL_INC=../../../openssl-1.1.0f/include
+SSL_LIB32=../../../openssl-1.1.0f/win32/libssl.a
+CRYPTO_LIB32=../../../openssl-1.1.0f/win32/libcrypto.a
+SSL_LIB64=../../../openssl-1.1.0f/win64/libssl.a
+CRYPTO_LIB64=../../../openssl-1.1.0f/win64/libcrypto.a
+
+#Local include directory
+BINDING_INC=../bindings-pkcs11
+
+# Libname to compile
+LIBNAME="softhsm"
+ 
+# Output LIB
+CLIENTLIB=libp11client
+
+#Modify SOCKET_PATH LIBNAME to your convenience
+LCFLAGS=-g -I$(RPC_INC) -I$(BINDING_INC) -I.\
+	-DONCRPC_STATIC\
+	-DCRPC \
+	-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero \
+	-DTCP_SOCKET  -DSOCKET_PATH=127.0.0.1:4444\
+	-DLIBNAME=$(LIBNAME)\
+
+LINK_FLAGS32=$(RPC_LIB32)
+LINK_FLAGS64=$(RPC_LIB64)
+
+#Modify SOCKET_PATH LIBNAME to your convenience
+LCFLAGS_SSL=-g -I$(RPC_INC) -I$(BINDING_INC) -I. -I$(SSL_INC)\
+	-DONCRPC_STATIC\
+	-DCRPC \
+	-fno-builtin-bcopy -fno-builtin-bcmp -fno-builtin-bzero \
+	-DTCP_SOCKET  -DSOCKET_PATH=127.0.0.1:4444\
+	-DLIBNAME=$(LIBNAME)\
+	-DWITH_SSL -DSSL_FILES_ENV
+
+LINK_FLAGS32_SSL=$(RPC_LIB32) $(SSL_LIB32) $(CRYPTO_LIB32) -static-libgcc
+LINK_FLAGS64_SSL=$(RPC_LIB64) $(SSL_LIB64) $(CRYPTO_LIB64) -static-libgcc
+
+
+# Change to 64-bit mingw if you want 64-bit binaries
+MINGW32=i686-w64-mingw32
+MINGW64=x86_64-w64-mingw32
+CC32=$(MINGW32)-gcc
+CC64=$(MINGW64)-gcc
+
+TARGETS32=$(CLIENTLIB)_32.dll
+TARGETS64=$(CLIENTLIB)_64.dll
+TARGETS32_SSL=$(CLIENTLIB)_32_ssl.dll
+TARGETS64_SSL=$(CLIENTLIB)_64_ssl.dll
+TRASH=*.pdb *.lib *.exp *.idb *.manifest
+
+CLIENT_SRC =  \
+    pkcs11_rpc_xdr.c \
+	pkcs11_rpc_clnt.c \
+	modwrap.c \
+	modwrap_crpc.c \
+	modwrap_crpc_ssl.c \
+
+CLIENT_OBJ = $(patsubst %.c, %.o, $(CLIENT_SRC))
+ 	
+all:	winrpc objs32 clientlib32 objs64 clientlib64 objs32ssl clientlib32ssl objs64ssl clientlib64ssl
+
+clean:
+	rm -f $(TARGETS32) $(TARGETS64) $(TARGETS32_SSL) $(TARGETS64_SSL) $(CLIENT_OBJ) $(TRASH)
+
+# Copy the xdr files and generate the headers properly for 
+# the Win32 target 
+winrpc:
+	#Copy file in order to get correct include path in file generated
+	cp ../rpc-pkcs11/pkcs11_rpc.x ./
+	#Generate header for Win32 compatibility (i.e. without MT support)
+	rpcgen -h -N pkcs11_rpc.x > pkcs11_rpc.h
+	#Generate xdr helpers
+	rpcgen -c -N pkcs11_rpc.x > pkcs11_rpc_xdr.c
+	#Generate client stubs
+	rpcgen -l -N pkcs11_rpc.x > pkcs11_rpc_clnt.c
+	#Remove local copy of XDR file
+	rm pkcs11_rpc.x
+	#Patch generated xdr implementation (optional: remove unused buffer)
+	spatch --no-show-diff --sp-file ./pkcs11_rpc_xdr.cocci ./pkcs11_rpc_xdr.c --in-place
+
+
+#Compile and link 32-bit
+objs32:
+	$(CC32) $(LCFLAGS) -c $(CLIENT_SRC)
+
+clientlib32: $(CLIENT_OBJ)
+	$(CC32) -shared -o $(TARGETS32) $(CLIENT_OBJ) $(LINK_FLAGS32) -lwsock32
+
+objs32ssl:
+	$(CC32) $(LCFLAGS_SSL) -c $(CLIENT_SRC)
+
+clientlib32ssl: $(CLIENT_OBJ)
+	$(CC32) -shared -o $(TARGETS32_SSL) $(CLIENT_OBJ) $(LINK_FLAGS32_SSL) -lwsock32 -lgdi32 -lws2_32
+
+#Compile and link 64-bit
+objs64:
+	$(CC64) $(LCFLAGS) -c $(CLIENT_SRC)
+
+clientlib64: $(CLIENT_OBJ)
+	$(CC64) -shared -o $(TARGETS64) $(CLIENT_OBJ) $(LINK_FLAGS64) -lwsock32
+
+objs64ssl:
+	$(CC64) $(LCFLAGS_SSL) -c $(CLIENT_SRC)
+
+clientlib64ssl: $(CLIENT_OBJ)
+	$(CC64) -shared -o $(TARGETS64_SSL) $(CLIENT_OBJ) $(LINK_FLAGS64_SSL) -lwsock32 -lgdi32 -lws2_32

--- a/src/client-lib/modwrap.c
+++ b/src/client-lib/modwrap.c
@@ -350,6 +350,7 @@ void custom_sanitize_ck_mechanism(struct ck_mechanism *mech)
       (*mech).parameter = NULL;
       (*mech).parameter_len = 0;
     }
+    /* Fallthrough */
   default:
     {
       if ((*mech).parameter_len > MAX_BUFF_LEN) {

--- a/src/filter/filter/Makefile.in
+++ b/src/filter/filter/Makefile.in
@@ -1,7 +1,7 @@
 all:
-	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter_common -c @srcdir@/filter_common.ml
-	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter_actions -c @srcdir@/filter_actions.ml
-	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter_configuration -c @srcdir@/filter_configuration.ml
-	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter -c @srcdir@/filter.ml
+	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo @ocaml_with_bytes_module@ -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter_common -c @srcdir@/filter_common.ml
+	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo @ocaml_with_bytes_module@ -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter_actions -c @srcdir@/filter_actions.ml
+	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo @ocaml_with_bytes_module@ -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter_configuration -c @srcdir@/filter_configuration.ml
+	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo @ocaml_with_bytes_module@ -I @srcdir@  " -package "str,config-file,netplex" -I ../../bindings-pkcs11 -I ../backend -o filter -c @srcdir@/filter.ml
 clean:
 	@rm -f *.cmi *.cmx *.o *.cmo *~ *.opt 

--- a/src/filter/filter/filter.ml
+++ b/src/filter/filter/filter.ml
@@ -293,9 +293,9 @@ let remove_elements_from_array array_ref to_remove =
 
 let pickup_elements_in_array array_ref count = 
   (* Exract count elements from the array *)
-  let extracted = try Array.sub !array_ref 0 (Nativeint.to_int count)
+  let extracted = (try Array.sub !array_ref 0 (Nativeint.to_int count)
     (* If count is larger than the size, we return the whole *)
-    with Invalid_argument "Array.sub" -> (Array.copy !array_ref)  in
+    with Invalid_argument _ -> (Array.copy !array_ref))  in
   let _ = remove_elements_from_array array_ref extracted in
   (extracted)
 

--- a/src/filter/filter/filter_actions_helpers/helpers_patch.ml
+++ b/src/filter/filter/filter_actions_helpers/helpers_patch.ml
@@ -432,7 +432,7 @@ let execute_external_command command data argvs env =
   let buffer_stderr = Buffer.create buffer_size in
   (* Append the argvs to the command *)
   let command = String.concat " " (List.concat [ [command]; Array.to_list argvs ]) in
-  let string = String.create buffer_size in
+  let string = Bytes.create buffer_size in
   let (in_channel_stdout, out_channel, in_channel_stderr) = Unix.open_process_full command [||] in
   (* Write data to out_channel *)
   output out_channel data 0 (String.length data);

--- a/src/filter/filter/filter_actions_helpers/helpers_patch.ml
+++ b/src/filter/filter/filter_actions_helpers/helpers_patch.ml
@@ -73,6 +73,12 @@
     File:    src/filter/filter/filter_actions_helpers/helpers_patch.ml
 
 ************************** MIT License HEADER ***********************************)
+
+(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
+IFNDEF OCAML_WITH_BYTES_MODULE THEN
+module Bytes = String
+ENDIF
+
 (* Global value to tell if we want to segregate usage *)
 let segregate_usage = ref false
 

--- a/src/filter/filter/filter_configuration.ml
+++ b/src/filter/filter/filter_configuration.ml
@@ -78,6 +78,11 @@ open Config_file
 open Filter_common
 open Filter_actions
 
+(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
+IFNDEF OCAML_WITH_BYTES_MODULE THEN
+module Bytes = String
+ENDIF
+
 let string_check_function a = match a with
   "C_LoadModule" -> a
 | "C_Initialize" -> a

--- a/src/filter/filter/filter_configuration.ml
+++ b/src/filter/filter/filter_configuration.ml
@@ -659,7 +659,7 @@ let print_some_help groupable_cp _ _ filename _ =
 let load_file f =
   let ic = open_in f in
   let n = in_channel_length ic in
-  let s = String.create n in
+  let s = Bytes.create n in
   really_input ic s 0 n;
   close_in ic;
   (s)

--- a/src/pkcs11proxyd/Makefile.in
+++ b/src/pkcs11proxyd/Makefile.in
@@ -11,7 +11,7 @@ sysconf=${DESTDIR}@sysconfdir@
 
 all:
 	#Compile Server
-	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo -I @srcdir@ @caml_server_daemonize_define@ @caml_server_ssl_define@ @filter_define@" -package "netplex" @filter_include@ @caml_server_ssl_package@ -I $(bindings_dir) -I $(rpc-pkcs11_dir) -o server -c @srcdir@/server.ml
+	ocamlfind ocamlopt -pp "camlp4o pa_macro.cmo -I @srcdir@ @caml_server_daemonize_define@ @caml_server_ssl_define@ @filter_define@ @ocaml_with_bytes_module@" -package "netplex" @filter_include@ @caml_server_ssl_package@ -I $(bindings_dir) -I $(rpc-pkcs11_dir) -o server -c @srcdir@/server.ml
 	ocamlfind ocamlopt @filter_include@ -package "str,netplex,config-file" @caml_server_ssl_package@ -linkpkg $(bindings_dir)/pkcs11.cmxa @filter_files@ $(rpc-pkcs11_dir)/pkcs11_rpclib.cmxa server.cmx $(caml_link_dirs) $(mem_prot_opt_caml) -o $(server_name)
 
 install:

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -84,10 +84,124 @@ Nettls_gnutls.init();
 ENDIF
 ENDIF
 
+(* Basic helpers *)
+let read_file f =
+  let ic = open_in f in
+  let n = in_channel_length ic in
+  let s = Bytes.create n in
+  really_input ic s 0 n;
+  close_in ic;
+  (s)
+
+let write_file f s =
+  let oc = open_out f in
+  Printf.fprintf oc "%s" s;
+  close_out oc;
+  ()
+
+(**** For OCamlnet >= 4, we do two things:                                   *)
+(*     - (Dirty) Workaround for an issue with default peer_auth verification *)
+(*     - Implement a proper certificate white list verification              *)
+(* Ocamlnet is 4.x *)
+
+IFDEF WITH_SSL_LEGACY THEN
+let write_certificate tmp_file client_cert = Ssl.write_certificate tmp_file client_cert
+ELSE
+let write_certificate tmp_file client_cert = write_file tmp_file client_cert
+ENDIF
+
+let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
+  match allowed_clients_cert_path with
+     None -> true
+   | Some path ->
+     (* Go through all the client certificates in the path *)
+     let check_dir = (try Sys.is_directory path with
+       _ -> false) in
+     if check_dir = true then
+       (* List all files in the directory *)
+       let cert_files = Sys.readdir path in
+       (* Get the client certificate string *)
+       let tmp_file = Filename.temp_file "pkcs11proxy_server" "client_cert" in
+       let _ = write_certificate tmp_file client_cert in
+       (* Read the cert file as a string *)
+       let client_cert_string = read_file tmp_file in
+       let check = ref false in
+       Array.iter (
+         fun file_name ->
+           let to_compare = (try read_file (path ^ Filename.dir_sep ^ file_name) with
+             _ ->  ""
+           )  in
+           if compare to_compare "" = 0 then
+             check := !check || false
+           else
+             if compare to_compare client_cert_string = 0 then
+               check := !check || true
+             else
+               check := !check || false
+       ) cert_files;
+       (!check)
+     else
+       let s = Printf.sprintf "Error: forbidden client certificates folder %s does not exist!" path in
+       Netplex_cenv.log `Err s;
+       (false)
+
+IFNDEF WITH_SSL_LEGACY THEN
+(* Stolen from OCamlnet Nettls *)
+let create_pem header_tag data =
+  let b64 = Netencoding.Base64.encode ~linelength:64 data in
+  "-----BEGIN " ^ header_tag ^ "-----\n" ^ 
+    b64 ^
+      "-----END " ^ header_tag ^ "-----\n"
+
+let allowed_clients_cert_path_ref = ref None
+let my_cert_check cert =
+  (* Extract the DER string *)
+  match cert with
+  | `X509(der_cert) -> 
+    (* We have two cases here: either we have a white list of client certificates, or not *)
+    let x509_cert = new Netx509.x509_certificate_from_DER der_cert in
+    let user = x509_cert # subject # string in
+    (* DER to PEM *)
+    let pem_cert = create_pem "CERTIFICATE" der_cert in
+    let is_client_allowed = check_is_client_certificate_allowed !allowed_clients_cert_path_ref pem_cert in
+    if is_client_allowed = false then
+      let s = Printf.sprintf "Unsupported client certificate for user=%s" user in
+      Netplex_cenv.log `Err s;
+      (false)
+    else
+      let s = Printf.sprintf "user=%s" user in
+      Netplex_cenv.log `Info s;
+      (true)
+  | _ -> (false)
+
+
+let verify endpoint p_trust p_hostmatch =
+  let module Endpoint = (val endpoint : Netsys_crypto_types.TLS_ENDPOINT) in
+  let cert = Endpoint.TLS.get_peer_creds Endpoint.endpoint in
+  (* We do not check for the host name since we deal with a client! (this is a dirty 'hack' of the way *)
+  (* OCamlnet TLS module deals with name verification in the client case ...                           *)
+  (* FIXME: add the '&& p_hostmatch' boolean in the return value when fixed in OCamlnet                *)
+  (p_trust && (my_cert_check cert))
+ENDIF
+
 IFDEF WITH_SSL THEN
 let fetch_ssl_params use_ssl cf addr =
 IFNDEF WITH_SSL_LEGACY THEN
-  let tls_config = Netplex_config.read_tls_config cf addr (Netsys_crypto.current_tls_opt()) in
+  (* First, we extract our client certificate white list if there is one *)
+  let _ = (allowed_clients_cert_path_ref :=
+    try
+      Some (cf # string_param (cf # resolve_parameter addr "allowed_clients_cert_path"))
+    with
+      | Not_found -> (None);) in
+  let _ = (if !allowed_clients_cert_path_ref = None
+  then
+  begin
+      let s = Printf.sprintf "CONFIGURATION: you did not set any allowed_clients_cert_path, any client with a proper certificate will be accepted" in
+      Netplex_cenv.log `Info s;
+  end) in
+  (* Note: we override the ~verify parameter here to properly implement a peer_auth "required" and *)
+  (* also implement our certificate white list verification *)
+  let tls_config = Netplex_config.read_tls_config ~verify cf addr (Netsys_crypto.current_tls_opt()) in
     (use_ssl, tls_config)
 ELSE
   match use_ssl with
@@ -300,90 +414,6 @@ let check_empty_negative_only_suites ciphers =
       (ciphers)
   end
 
-(* This function checks in the allowed_clients_cert_path folder if a given client *)
-(* is allowed                                                                     *)
-let read_file f =
-  let ic = open_in f in
-  let n = in_channel_length ic in
-  let s = String.create n in
-  really_input ic s 0 n;
-  close_in ic;
-  (s)
-
-let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
-  match allowed_clients_cert_path with
-     None -> true
-   | Some path ->
-     (* Go through all the client certificates in the path *)
-     let check_dir = (try Sys.is_directory path with
-       _ -> false) in
-     if check_dir = true then
-       (* List all files in the directory *)
-       let cert_files = Sys.readdir path in
-       (* Get the client certificate string *)
-       let tmp_file = Filename.temp_file "pkcs11proxy_server" "client_cert" in
-       let _ = Ssl.write_certificate tmp_file client_cert in
-       (* Read the cert file as a string *)
-       let client_cert_string = read_file tmp_file in
-       let check = ref false in
-       Array.iter (
-         fun file_name ->
-           let to_compare = (try read_file (path ^ Filename.dir_sep ^ file_name) with
-             _ ->  ""
-           )  in
-           if compare to_compare "" = 0 then
-             check := !check || false
-           else
-             if compare to_compare client_cert_string = 0 then
-               check := !check || true
-             else
-               check := !check || false
-       ) cert_files;
-       (!check)
-     else
-       let s = Printf.sprintf "Error: forbidden client certificates folder %s does not exist!" path in
-       failwith s
-(* Ocamlnet is 4.x *)
-(*
-let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
-  match allowed_clients_cert_path with
-     None -> true
-   | Some path ->
-     (*
-     (* Go through all the client certificates in the path *)
-     let check_dir = (try Sys.is_directory path with
-       _ -> false) in
-     if check_dir = true then
-       (* List all files in the directory *)
-       let cert_files = Sys.readdir path in
-       (* Get the client certificate string *)
-       let tmp_file = Filename.temp_file "pkcs11proxy_server" "client_cert" in
-       let _ = Ssl.write_certificate tmp_file client_cert in
-       (* Read the cert file as a string *)
-       let client_cert_string = read_file tmp_file in
-       let check = ref false in
-       Array.iter (
-         fun file_name ->
-           let to_compare = (try read_file (path ^ Filename.dir_sep ^ file_name) with
-             _ ->  ""
-           )  in
-           if compare to_compare "" = 0 then
-             check := !check || false
-           else
-             if compare to_compare client_cert_string = 0 then
-               check := !check || true
-             else
-               check := !check || false
-       ) cert_files;
-       (!check)
-     else
-       let s = Printf.sprintf "Error: forbidden client certificates folder %s does not exist!" path in
-       failwith s
-    *)
-    true
-ENDIF
-*)
-
 let my_socket_config use_ssl cafile certfile certkey cipher_suite dh_params ec_curve_name verify_depth allowed_clients_cert_path =
   match use_ssl with
   | true ->
@@ -470,4 +500,3 @@ let socket_config (use_ssl, tls_config) =
     |Some config -> Rpc_server.tls_socket_config config)
 ENDIF
 ENDIF
-

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -169,7 +169,7 @@ let my_cert_check cert =
       Netplex_cenv.log `Err s;
       (false)
     else
-      let s = Printf.sprintf "user=%s" user in
+      let s = Printf.sprintf "user=%s is authenticated and connected" user in
       Netplex_cenv.log `Info s;
       (true)
   | _ -> (false)
@@ -479,7 +479,8 @@ let my_socket_config use_ssl cafile certfile certkey cipher_suite dh_params ec_c
                      let _ = Ssl.shutdown sslsock in
                      failwith s
                    else
-                     prerr_endline ("user=" ^ user);
+                     let s = Printf.sprintf "user=%s is authenticated and connected" user in
+                     Netplex_cenv.log `Info s;
                      Some user)
         ctx
     | false -> Rpc_server.default_socket_config

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -469,7 +469,6 @@ let my_socket_config use_ssl cafile certfile certkey cipher_suite dh_params ec_c
 
     Rpc_ssl.ssl_server_socket_config
       ~get_peer_user_name:(fun _ sslsock ->
-                   prerr_endline "get_peer_user_name";
                    let cert = Ssl.get_certificate sslsock in
                    let user = Ssl.get_subject cert in
                    (* Check peer client certificate *)

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -70,6 +70,11 @@
 
 ************************** MIT License HEADER *********************************)
 
+(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
+IFNDEF OCAML_WITH_BYTES_MODULE THEN
+module Bytes = String
+ENDIF
+
 IFDEF WITH_SSL THEN
 (* Reference those two variables here to avoid circulare dependencies *)
 let libnames_config_ref = ref ""


### PR DESCRIPTION
client library.

This Makefile supposes:

1) That i686-w64-mingw32 and x86_64-w64-mingw32 cross-compilation toolchain are
both installed on the system.

2) That the oncrpc-win32 includes and 32-bit/64-bit libraries have been compiled
or downloaded in the relative paths: oncrpc-win32/win32/include for the includes,
../oncrpc-win32/win32/bin32/oncrpc.lib for the 32-bit oncrpc static library, and
../oncrpc-win32/win32/bin64/oncrpc.lib for the 64-but oncrpc static library.

3) The the OpenSSL includes and 32-bit/64-bit libraries have been compiled
or downloaded in the relative paths: ../openssl-1.1.0f/include for the includes,
../openssl-1.1.0f/win32/libssl.a for the 32-bit libssl static library,
../openssl-1.1.0f/win32/libcrypto.a for the 32-bit librcypto static library,
../openssl-1.1.0f/win64/libssl.a for the 64-bit libssl static library, and
../openssl-1.1.0f/win64/libcrypto.a for the 64-bit libcrypto static library.

The Makefile 'Makefile.Win32.mingw' can be adapted to only compile and use 32-bit
or 64-bit binaries. i686-w64-mingw32 and x86_64-w64-mingw32 and other elements
(such as the CamlCrush client libname and socket) are hardcoded: improving and
cleaning the Makefile to be more flexible and adapt to other systems are future
work.

Launching the standalone compilation of the client library is as easy as
(from the CamlCrush project root folder):
$ cd src/client-lib
$ make -f Makefile.Win32.mingw

This should produce:
libp11client_32.dll => the 32-bit client library WITHOUT the SSL support.
libp11client_32_ssl.dll => the 32-bit client library WITH the SSL support.
libp11client_64.dll => the 64-bit client library WITHOUT the SSL support.
libp11client_64_ssl.dll => the 64-bit client library WITH the SSL support.

This version have been tested against:
- The oncrpc library compiled with Mingw, see:
  https://github.com/calderonth/oncrpc-win32
- OpenSSL in version 1.1.0f compiled with Mingw (see the NOTES.WIN file
section "GNU C (MinGW/MSYS)" at the root folder of the project).

Even though it has not been tested, the current Makefile.Win32.mingw should
also work with static libraries for oncrpc and OpenSSL compiled with other
Win32/Win64 compatible compilers (such as Visual C++).