### PR TITLE
Various fixes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -557,6 +557,7 @@ then
 		AC_CHECK_OCAML_PKG([ssl], ssl)
                 # Check for the ocaml-ssl version: we only support
                 # version >= 0.4.7
+		AC_CHECK_OCAML_PKG_VERS([ssl], ssl)
                 AX_COMPARE_VERSION([$pkg_vers_ssl], [lt], [0.4.7], [ocaml_ssl_bad_version=yes], [ocaml_ssl_bad_version=no])
                 if test "$ocaml_ssl_bad_version" == "yes"
                 then

--- a/src/bindings-pkcs11/pkcs11.idl
+++ b/src/bindings-pkcs11/pkcs11.idl
@@ -3176,8 +3176,8 @@ quote(mli, "val sprint_bool_attribute_value : nativeint -> string\n");
 quote(mli, "val sprint_template_array : ck_attribute array -> string\n");
 
 quote(ml,
-      "let char_array_to_string = fun a -> let s = String.create (Array.length a) in\n");
-quote(ml, "  Array.iteri (fun i x -> String.set s i x) a; s;;\n");
+      "let char_array_to_string = fun a -> let s = Bytes.create (Array.length a) in\n");
+quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; s;;\n");
 
 quote(ml,
       "let string_to_char_array = fun s -> Array.init (String.length s) (fun i -> s.[i]);;\n");
@@ -3248,13 +3248,13 @@ quote(ml, "    (res);;");
 quote(ml, "let pack hexstr =");
 quote(ml, "     let len = String.length hexstr in");
 quote(ml, "     let half_len = len / 2 in");
-quote(ml, "     let res = String.create half_len in");
+quote(ml, "     let res = Bytes.create half_len in");
 quote(ml, "     let j = ref 0 in");
 quote(ml, "     for i = 0 to len - 2 do");
 quote(ml, "        if (i mod 2 == 0) then");
 quote(ml, "          (");
 quote(ml, "          let tmp = merge_nibbles hexstr.[i] hexstr.[i+1] in");
-quote(ml, "          res.[!j] <- tmp;");
+quote(ml, "          Bytes.set res !j tmp;");
 quote(ml, "          j := !j +1;");
 quote(ml, "          )");
 quote(ml, "     done;");

--- a/src/bindings-pkcs11/pkcs11.idl
+++ b/src/bindings-pkcs11/pkcs11.idl
@@ -3175,6 +3175,10 @@ quote(mli, "val char_array_to_bool : char array -> nativeint\n");
 quote(mli, "val sprint_bool_attribute_value : nativeint -> string\n");
 quote(mli, "val sprint_template_array : ck_attribute array -> string\n");
 
+/* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module */
+#ifndef OCAML_WITH_BYTES_MODULE 
+quote(ml, "module Bytes = String");
+#endif
 quote(ml,
       "let char_array_to_string = fun a -> let s = Bytes.create (Array.length a) in\n");
 quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; s;;\n");

--- a/src/bindings-pkcs11/pkcs11_stubs.cocci
+++ b/src/bindings-pkcs11/pkcs11_stubs.cocci
@@ -334,6 +334,7 @@ identifier _ctx, _c2, _v4, _c5, _c6, _v7;
 +      }
 +#endif
 +    }
++    /* Fallthrough */
 +    default:  {
 +      if ((long)_c5 >= 0) {
 +        (*_c2).value = camlidl_malloc(_c5 * sizeof(char), _ctx);

--- a/src/client-lib/modwrap.c
+++ b/src/client-lib/modwrap.c
@@ -350,6 +350,7 @@ void custom_sanitize_ck_mechanism(struct ck_mechanism *mech)
       (*mech).parameter = NULL;
       (*mech).parameter_len = 0;
     }
+    /* Fallthrough */
   default:
     {
       if ((*mech).parameter_len > MAX_BUFF_LEN) {

--- a/src/filter/filter/filter.ml
+++ b/src/filter/filter/filter.ml
@@ -293,9 +293,9 @@ let remove_elements_from_array array_ref to_remove =
 
 let pickup_elements_in_array array_ref count = 
   (* Exract count elements from the array *)
-  let extracted = try Array.sub !array_ref 0 (Nativeint.to_int count)
+  let extracted = (try Array.sub !array_ref 0 (Nativeint.to_int count)
     (* If count is larger than the size, we return the whole *)
-    with Invalid_argument "Array.sub" -> (Array.copy !array_ref)  in
+    with Invalid_argument _ -> (Array.copy !array_ref))  in
   let _ = remove_elements_from_array array_ref extracted in
   (extracted)
 

--- a/src/filter/filter/filter_actions_helpers/helpers_patch.ml
+++ b/src/filter/filter/filter_actions_helpers/helpers_patch.ml
@@ -432,7 +432,7 @@ let execute_external_command command data argvs env =
   let buffer_stderr = Buffer.create buffer_size in
   (* Append the argvs to the command *)
   let command = String.concat " " (List.concat [ [command]; Array.to_list argvs ]) in
-  let string = String.create buffer_size in
+  let string = Bytes.create buffer_size in
   let (in_channel_stdout, out_channel, in_channel_stderr) = Unix.open_process_full command [||] in
   (* Write data to out_channel *)
   output out_channel data 0 (String.length data);

--- a/src/filter/filter/filter_actions_helpers/helpers_patch.ml
+++ b/src/filter/filter/filter_actions_helpers/helpers_patch.ml
@@ -73,6 +73,12 @@
     File:    src/filter/filter/filter_actions_helpers/helpers_patch.ml
 
 ************************** MIT License HEADER ***********************************)
+
+(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
+IFNDEF OCAML_WITH_BYTES_MODULE THEN
+module Bytes = String
+ENDIF
+
 (* Global value to tell if we want to segregate usage *)
 let segregate_usage = ref false
 

--- a/src/filter/filter/filter_configuration.ml
+++ b/src/filter/filter/filter_configuration.ml
@@ -78,6 +78,11 @@ open Config_file
 open Filter_common
 open Filter_actions
 
+(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
+IFNDEF OCAML_WITH_BYTES_MODULE THEN
+module Bytes = String
+ENDIF
+
 let string_check_function a = match a with
   "C_LoadModule" -> a
 | "C_Initialize" -> a

--- a/src/filter/filter/filter_configuration.ml
+++ b/src/filter/filter/filter_configuration.ml
@@ -659,7 +659,7 @@ let print_some_help groupable_cp _ _ filename _ =
 let load_file f =
   let ic = open_in f in
   let n = in_channel_length ic in
-  let s = String.create n in
+  let s = Bytes.create n in
   really_input ic s 0 n;
   close_in ic;
   (s)

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -84,10 +84,124 @@ Nettls_gnutls.init();
 ENDIF
 ENDIF
 
+(* Basic helpers *)
+let read_file f =
+  let ic = open_in f in
+  let n = in_channel_length ic in
+  let s = Bytes.create n in
+  really_input ic s 0 n;
+  close_in ic;
+  (s)
+
+let write_file f s =
+  let oc = open_out f in
+  Printf.fprintf oc "%s" s;
+  close_out oc;
+  ()
+
+(**** For OCamlnet >= 4, we do two things:                                   *)
+(*     - (Dirty) Workaround for an issue with default peer_auth verification *)
+(*     - Implement a proper certificate white list verification              *)
+(* Ocamlnet is 4.x *)
+
+IFDEF WITH_SSL_LEGACY THEN
+let write_certificate tmp_file client_cert = Ssl.write_certificate tmp_file client_cert
+ELSE
+let write_certificate tmp_file client_cert = write_file tmp_file client_cert
+ENDIF
+
+let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
+  match allowed_clients_cert_path with
+     None -> true
+   | Some path ->
+     (* Go through all the client certificates in the path *)
+     let check_dir = (try Sys.is_directory path with
+       _ -> false) in
+     if check_dir = true then
+       (* List all files in the directory *)
+       let cert_files = Sys.readdir path in
+       (* Get the client certificate string *)
+       let tmp_file = Filename.temp_file "pkcs11proxy_server" "client_cert" in
+       let _ = write_certificate tmp_file client_cert in
+       (* Read the cert file as a string *)
+       let client_cert_string = read_file tmp_file in
+       let check = ref false in
+       Array.iter (
+         fun file_name ->
+           let to_compare = (try read_file (path ^ Filename.dir_sep ^ file_name) with
+             _ ->  ""
+           )  in
+           if compare to_compare "" = 0 then
+             check := !check || false
+           else
+             if compare to_compare client_cert_string = 0 then
+               check := !check || true
+             else
+               check := !check || false
+       ) cert_files;
+       (!check)
+     else
+       let s = Printf.sprintf "Error: forbidden client certificates folder %s does not exist!" path in
+       Netplex_cenv.log `Err s;
+       (false)
+
+IFNDEF WITH_SSL_LEGACY THEN
+(* Stolen from OCamlnet Nettls *)
+let create_pem header_tag data =
+  let b64 = Netencoding.Base64.encode ~linelength:64 data in
+  "-----BEGIN " ^ header_tag ^ "-----\n" ^ 
+    b64 ^
+      "-----END " ^ header_tag ^ "-----\n"
+
+let allowed_clients_cert_path_ref = ref None
+let my_cert_check cert =
+  (* Extract the DER string *)
+  match cert with
+  | `X509(der_cert) -> 
+    (* We have two cases here: either we have a white list of client certificates, or not *)
+    let x509_cert = new Netx509.x509_certificate_from_DER der_cert in
+    let user = x509_cert # subject # string in
+    (* DER to PEM *)
+    let pem_cert = create_pem "CERTIFICATE" der_cert in
+    let is_client_allowed = check_is_client_certificate_allowed !allowed_clients_cert_path_ref pem_cert in
+    if is_client_allowed = false then
+      let s = Printf.sprintf "Unsupported client certificate for user=%s" user in
+      Netplex_cenv.log `Err s;
+      (false)
+    else
+      let s = Printf.sprintf "user=%s" user in
+      Netplex_cenv.log `Info s;
+      (true)
+  | _ -> (false)
+
+
+let verify endpoint p_trust p_hostmatch =
+  let module Endpoint = (val endpoint : Netsys_crypto_types.TLS_ENDPOINT) in
+  let cert = Endpoint.TLS.get_peer_creds Endpoint.endpoint in
+  (* We do not check for the host name since we deal with a client! (this is a dirty 'hack' of the way *)
+  (* OCamlnet TLS module deals with name verification in the client case ...                           *)
+  (* FIXME: add the '&& p_hostmatch' boolean in the return value when fixed in OCamlnet                *)
+  (p_trust && (my_cert_check cert))
+ENDIF
+
 IFDEF WITH_SSL THEN
 let fetch_ssl_params use_ssl cf addr =
 IFNDEF WITH_SSL_LEGACY THEN
-  let tls_config = Netplex_config.read_tls_config cf addr (Netsys_crypto.current_tls_opt()) in
+  (* First, we extract our client certificate white list if there is one *)
+  let _ = (allowed_clients_cert_path_ref :=
+    try
+      Some (cf # string_param (cf # resolve_parameter addr "allowed_clients_cert_path"))
+    with
+      | Not_found -> (None);) in
+  let _ = (if !allowed_clients_cert_path_ref = None
+  then
+  begin
+      let s = Printf.sprintf "CONFIGURATION: you did not set any allowed_clients_cert_path, any client with a proper certificate will be accepted" in
+      Netplex_cenv.log `Info s;
+  end) in
+  (* Note: we override the ~verify parameter here to properly implement a peer_auth "required" and *)
+  (* also implement our certificate white list verification *)
+  let tls_config = Netplex_config.read_tls_config ~verify cf addr (Netsys_crypto.current_tls_opt()) in
     (use_ssl, tls_config)
 ELSE
   match use_ssl with
@@ -300,90 +414,6 @@ let check_empty_negative_only_suites ciphers =
       (ciphers)
   end
 
-(* This function checks in the allowed_clients_cert_path folder if a given client *)
-(* is allowed                                                                     *)
-let read_file f =
-  let ic = open_in f in
-  let n = in_channel_length ic in
-  let s = String.create n in
-  really_input ic s 0 n;
-  close_in ic;
-  (s)
-
-let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
-  match allowed_clients_cert_path with
-     None -> true
-   | Some path ->
-     (* Go through all the client certificates in the path *)
-     let check_dir = (try Sys.is_directory path with
-       _ -> false) in
-     if check_dir = true then
-       (* List all files in the directory *)
-       let cert_files = Sys.readdir path in
-       (* Get the client certificate string *)
-       let tmp_file = Filename.temp_file "pkcs11proxy_server" "client_cert" in
-       let _ = Ssl.write_certificate tmp_file client_cert in
-       (* Read the cert file as a string *)
-       let client_cert_string = read_file tmp_file in
-       let check = ref false in
-       Array.iter (
-         fun file_name ->
-           let to_compare = (try read_file (path ^ Filename.dir_sep ^ file_name) with
-             _ ->  ""
-           )  in
-           if compare to_compare "" = 0 then
-             check := !check || false
-           else
-             if compare to_compare client_cert_string = 0 then
-               check := !check || true
-             else
-               check := !check || false
-       ) cert_files;
-       (!check)
-     else
-       let s = Printf.sprintf "Error: forbidden client certificates folder %s does not exist!" path in
-       failwith s
-(* Ocamlnet is 4.x *)
-(*
-let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
-  match allowed_clients_cert_path with
-     None -> true
-   | Some path ->
-     (*
-     (* Go through all the client certificates in the path *)
-     let check_dir = (try Sys.is_directory path with
-       _ -> false) in
-     if check_dir = true then
-       (* List all files in the directory *)
-       let cert_files = Sys.readdir path in
-       (* Get the client certificate string *)
-       let tmp_file = Filename.temp_file "pkcs11proxy_server" "client_cert" in
-       let _ = Ssl.write_certificate tmp_file client_cert in
-       (* Read the cert file as a string *)
-       let client_cert_string = read_file tmp_file in
-       let check = ref false in
-       Array.iter (
-         fun file_name ->
-           let to_compare = (try read_file (path ^ Filename.dir_sep ^ file_name) with
-             _ ->  ""
-           )  in
-           if compare to_compare "" = 0 then
-             check := !check || false
-           else
-             if compare to_compare client_cert_string = 0 then
-               check := !check || true
-             else
-               check := !check || false
-       ) cert_files;
-       (!check)
-     else
-       let s = Printf.sprintf "Error: forbidden client certificates folder %s does not exist!" path in
-       failwith s
-    *)
-    true
-ENDIF
-*)
-
 let my_socket_config use_ssl cafile certfile certkey cipher_suite dh_params ec_curve_name verify_depth allowed_clients_cert_path =
   match use_ssl with
   | true ->
@@ -470,4 +500,3 @@ let socket_config (use_ssl, tls_config) =
     |Some config -> Rpc_server.tls_socket_config config)
 ENDIF
 ENDIF
-

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -169,7 +169,7 @@ let my_cert_check cert =
       Netplex_cenv.log `Err s;
       (false)
     else
-      let s = Printf.sprintf "user=%s" user in
+      let s = Printf.sprintf "user=%s is authenticated and connected" user in
       Netplex_cenv.log `Info s;
       (true)
   | _ -> (false)
@@ -479,7 +479,8 @@ let my_socket_config use_ssl cafile certfile certkey cipher_suite dh_params ec_c
                      let _ = Ssl.shutdown sslsock in
                      failwith s
                    else
-                     prerr_endline ("user=" ^ user);
+                     let s = Printf.sprintf "user=%s is authenticated and connected" user in
+                     Netplex_cenv.log `Info s;
                      Some user)
         ctx
     | false -> Rpc_server.default_socket_config

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -469,7 +469,6 @@ let my_socket_config use_ssl cafile certfile certkey cipher_suite dh_params ec_c
 
     Rpc_ssl.ssl_server_socket_config
       ~get_peer_user_name:(fun _ sslsock ->
-                   prerr_endline "get_peer_user_name";
                    let cert = Ssl.get_certificate sslsock in
                    let user = Ssl.get_subject cert in
                    (* Check peer client certificate *)

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -70,6 +70,11 @@
 
 ************************** MIT License HEADER *********************************)
 
+(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
+IFNDEF OCAML_WITH_BYTES_MODULE THEN
+module Bytes = String
+ENDIF
+
 IFDEF WITH_SSL THEN
 (* Reference those two variables here to avoid circulare dependencies *)
 let libnames_config_ref = ref ""


### PR DESCRIPTION
Various improvements and fixes, mostly:
1) Handle the Ocamlnet 'peer_auth=required' issue (issue #29) with a workaround.
2) Add a way to handle client certificates white list that disappeared when migrating to Ocamlnet >= 4 (due to underlying TLS library migration). The work is inspired from https://sourceforge.net/p/ocamlnet/mailman/message/34653236/.
3) Various small fixes (warnings of gcc and ocaml compiler).